### PR TITLE
Rename module to ai-stack

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,11 +5,11 @@
 
 ---
 
-# terraform-azurerm-azure-ai-foundry-hub
+# terraform-azurerm-ai-stack
 
-[![Terraform Registry](https://img.shields.io/badge/Terraform%20Registry-launchpad-7B42BC?style=for-the-badge&logo=terraform&logoColor=A067DA)](https://registry.terraform.io/modules/cloudeteer/launchpad/azurerm)
-[![OpenTofu Registry](https://img.shields.io/badge/OpenTofu%20Registry-launchpad-4B4B77?style=for-the-badge&logo=opentofu)](https://search.opentofu.org/module/cloudeteer/launchpad/azurerm)
-[![SemVer](https://img.shields.io/badge/SemVer-2.0.0-F77F00?style=for-the-badge)](https://github.com/cloudeteer/terraform-azurerm-launchpad/releases)
+[![Terraform Registry](https://img.shields.io/badge/Terraform%20Registry-ai-stack-7B42BC?style=for-the-badge&logo=terraform&logoColor=A067DA)](https://registry.terraform.io/modules/cloudeteer/ai-stack/azurerm)
+[![OpenTofu Registry](https://img.shields.io/badge/OpenTofu%20Registry-ai-stack-4B4B77?style=for-the-badge&logo=opentofu)](https://search.opentofu.org/module/cloudeteer/ai-stack/azurerm)
+[![SemVer](https://img.shields.io/badge/SemVer-2.0.0-F77F00?style=for-the-badge)](https://github.com/cloudeteer/terraform-azurerm-ai-stack/releases)
 
 This Terraform module is composed of several submodules, which are combined in the primary module to provide a complete solution. Each submodule can also be deployed independently—see [./modules/](./modules/) for details.
 
@@ -115,7 +115,7 @@ resource "azurerm_resource_group" "example" {
 }
 
 module "example" {
-  source = "cloudeteer/azure-ai-foundry-hub/azurerm"
+  source = "cloudeteer/ai-stack/azurerm"
 
   basename            = trimprefix(azurerm_resource_group.example.name, "rg-")
   location            = azurerm_resource_group.example.location
@@ -186,24 +186,24 @@ Description: The principal ID of a user or group of AI Developers who will have 
 
 The following roles will be assigned to the given principal ID:
 
-| Role                                     | Scope                    |
-| ---------------------------------------- | ------------------------ |
-| Azure AI Developer                       | AI Foundry Hub           |
-| Azure AI Developer                       | AI Foundry Project       |
-| Contributor                              | Developer Resource Group |
-| Storage Blob Data Contributor            | Storage Account          |
-| Storage File Data Privileged Contributor | Storage Account          |
-| Cognitive Services Contributor           | AI Service               |
-| Cognitive Services OpenAI Contributor    | AI Service               |
-| Cognitive Services User                  | AI Service               |
-| User Access Administrator                | AI Service               |
-| Search Index Data Contributor            | AI Search Service        |
-| Search Service Contributor               | AI Search Service        |
+| Role | Scope |
+| -- | -- |
+| Azure AI Developer | AI Foundry Hub |
+| Azure AI Developer | AI Foundry Project |
+| Contributor | Developer Resource Group |
+| Storage Blob Data Contributor | Storage Account |
+| Storage File Data Privileged Contributor | Storage Account |
+| Cognitive Services Contributor | AI Service |
+| Cognitive Services OpenAI Contributor | AI Service |
+| Cognitive Services User | AI Service |
+| User Access Administrator | AI Service |
+| Search Index Data Contributor | AI Search Service |
+| Search Service Contributor | AI Search Service |
 
-| Argument                | Description                                                                                                                                                      |
-| ----------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `isolation_mode`        | Isolation mode for the managed network of a machine learning workspace. Possible values are `AllowOnlyApprovedOutbound`, `AllowInternetOutbound`, or `Disabled`. |
-| `public_network_access` | Whether requests from Public Network are allowed.                                                                                                                |
+Argument | Description
+-- | --
+`isolation_mode` | Isolation mode for the managed network of a machine learning workspace. Possible values are `AllowOnlyApprovedOutbound`, `AllowInternetOutbound`, or `Disabled`.
+`public_network_access` | Whether requests from Public Network are allowed.
 
 **NOTE**: The `User Access Administrator` role is assigned with the condition that only the `Cognitive Services OpenAI User` role can be assigned to user principals. This is necessary to successfully deploy a Web App on top of an AI Model through the AI Foundry Hub.
 
@@ -223,13 +223,13 @@ Default: `[]`
 
 Description: If set to `true` (default), the following mandatory Azure role assignments will be created:
 
-| Role                                  | Scope             | Principal                  |
-| ------------------------------------- | ----------------- | -------------------------- |
-| Cognitive Services OpenAI Contributor | AI Service        | AI Search Service Identity |
-| Search Index Data Reader              | AI Search Service | AI Service Identity        |
-| Search Service Contributor            | AI Search Service | AI Service Identity        |
-| Storage Blob Data Contributor         | Storage Account   | AI Service Identity        |
-| Storage Blob Data Reader              | Storage Account   | AI Search Service Identity |
+| Role | Scope | Principal |
+| -- | -- | -- |
+| Cognitive Services OpenAI Contributor | AI Service | AI Search Service Identity |
+| Search Index Data Reader | AI Search Service | AI Service Identity |
+| Search Service Contributor | AI Search Service | AI Service Identity |
+| Storage Blob Data Contributor | Storage Account | AI Service Identity |
+| Storage Blob Data Reader | Storage Account | AI Search Service Identity |
 
 **NOTE**: If set to `false`, these role assignments must be created manually to ensure the AI Foundry Hub Project functions correctly.
 
@@ -259,10 +259,10 @@ Description: Network configuration for the AI Hub.
 
 Optional arguments:
 
-| Argument                | Description                                                                                                                                                      |
-| ----------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `isolation_mode`        | Isolation mode for the managed network of a machine learning workspace. Possible values are `AllowOnlyApprovedOutbound`, `AllowInternetOutbound`, or `Disabled`. |
-| `public_network_access` | Whether requests from Public Network are allowed.                                                                                                                |
+Argument | Description
+-- | --
+`isolation_mode` | Isolation mode for the managed network of a machine learning workspace. Possible values are `AllowOnlyApprovedOutbound`, `AllowInternetOutbound`, or `Disabled`.
+`public_network_access` | Whether requests from Public Network are allowed.
 
 **NOTE**:
 
@@ -299,19 +299,19 @@ Description: A list of models to deploy to the workspace.
 
 Required parameters:
 
-| Parameter | Description                                                                                                     |
-| --------- | --------------------------------------------------------------------------------------------------------------- |
-| `name`    | The name of the Cognitive Services Account Deployment model. Changing this forces a new resource to be created. |
+Parameter | Description
+-- | --
+`name` | The name of the Cognitive Services Account Deployment model. Changing this forces a new resource to be created.
 
 Optional parameters:
 
-| Parameter         | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    |
-| ----------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `deployment_name` | The name to assign to the model deployment. If not specified, the value of `name` will be used by default. This property allows you to customize the deployment resource name independently from the model name.                                                                                                                                                                                                                                                                                                                                               |
-| `format`          | The format of the Cognitive Services Account Deployment model. Changing this forces a new resource to be created. Possible value is `OpenAI`.                                                                                                                                                                                                                                                                                                                                                                                                                  |
-| `sku_capacity`    | Tokens-per-Minute (TPM). The unit of measure for this field is in the thousands of Tokens-per-Minute. Defaults to `1` which means that the limitation is `1000` tokens per minute. If the resources SKU supports scale in/out then the capacity field should be included in the resources' configuration. If the scale in/out is not supported by the resources SKU then this field can be safely omitted. For more information about TPM please see the [product documentation](https://learn.microsoft.com/azure/ai-services/openai/how-to/quota?tabs=rest). |
-| `sku_name`        | The name of the SKU. Possible values include `Standard`, `DataZoneStandard`, `DataZoneProvisionedManaged`, `GlobalBatch`, `GlobalProvisionedManaged`, `GlobalStandard`, and `ProvisionedManaged`.                                                                                                                                                                                                                                                                                                                                                              |
-| `version`         | The version of Cognitive Services Account Deployment model. If `version` is not specified, the default version of the model at the time will be assigned.                                                                                                                                                                                                                                                                                                                                                                                                      |
+Parameter | Description
+-- | --
+`deployment_name` | The name to assign to the model deployment. If not specified, the value of `name` will be used by default. This property allows you to customize the deployment resource name independently from the model name.
+`format` | The format of the Cognitive Services Account Deployment model. Changing this forces a new resource to be created. Possible value is `OpenAI`.
+`sku_capacity` | Tokens-per-Minute (TPM). The unit of measure for this field is in the thousands of Tokens-per-Minute. Defaults to `1` which means that the limitation is `1000` tokens per minute. If the resources SKU supports scale in/out then the capacity field should be included in the resources' configuration. If the scale in/out is not supported by the resources SKU then this field can be safely omitted. For more information about TPM please see the [product documentation](https://learn.microsoft.com/azure/ai-services/openai/how-to/quota?tabs=rest).
+`sku_name` | The name of the SKU. Possible values include `Standard`, `DataZoneStandard`, `DataZoneProvisionedManaged`, `GlobalBatch`, `GlobalProvisionedManaged`, `GlobalStandard`, and `ProvisionedManaged`.
+`version` | The version of Cognitive Services Account Deployment model. If `version` is not specified, the default version of the model at the time will be assigned.
 
 **Note**: `DataZoneProvisionedManaged`, `GlobalProvisionedManaged`, and `ProvisionedManaged` are purchased on-demand at an hourly basis based on the number of deployed PTUs, with substantial term discount available via the purchase of Azure Reservations. Currently, this step cannot be completed using Terraform. For more details, please refer to the [provisioned throughput onboarding documentation](https://learn.microsoft.com/en-us/azure/ai-services/openai/how-to/provisioned-throughput-onboarding).
 

--- a/examples/usage/main.tf
+++ b/examples/usage/main.tf
@@ -6,7 +6,7 @@ resource "azurerm_resource_group" "example" {
 }
 
 module "example" {
-  source = "cloudeteer/azure-ai-foundry-hub/azurerm"
+  source = "cloudeteer/ai-stack/azurerm"
 
   basename            = trimprefix(azurerm_resource_group.example.name, "rg-")
   location            = azurerm_resource_group.example.location

--- a/modules/ai-foundry-core/README.md
+++ b/modules/ai-foundry-core/README.md
@@ -5,7 +5,7 @@ This example demonstrates the usage of this Terraform module with default settin
 
 ```hcl
 module "ai_foundry_core" {
-  source = "cloudeteer/azure-ai-foundry-hub/azurerm//modules/ai-foundry-core"
+  source = "cloudeteer/ai-stack/azurerm//modules/ai-foundry-core"
 
   name                = var.basename
   location            = var.location

--- a/modules/ai-foundry-core/examples/usage/main.tf
+++ b/modules/ai-foundry-core/examples/usage/main.tf
@@ -1,5 +1,5 @@
 module "ai_foundry_core" {
-  source = "cloudeteer/azure-ai-foundry-hub/azurerm//modules/ai-foundry-core"
+  source = "cloudeteer/ai-stack/azurerm//modules/ai-foundry-core"
 
   name                = var.basename
   location            = var.location

--- a/modules/ai-foundry-services/README.md
+++ b/modules/ai-foundry-services/README.md
@@ -5,7 +5,7 @@ This example demonstrates the usage of this Terraform module with default settin
 
 ```hcl
 module "ai_foundry_services" {
-  source = "cloudeteer/azure-ai-foundry-hub/azurerm//modules/ai-foundry-services"
+  source = "cloudeteer/ai-stack/azurerm//modules/ai-foundry-services"
 
   name                = var.basename
   location            = var.location

--- a/modules/ai-foundry-services/examples/usage/main.tf
+++ b/modules/ai-foundry-services/examples/usage/main.tf
@@ -1,5 +1,5 @@
 module "ai_foundry_services" {
-  source = "cloudeteer/azure-ai-foundry-hub/azurerm//modules/ai-foundry-services"
+  source = "cloudeteer/ai-stack/azurerm//modules/ai-foundry-services"
 
   name                = var.basename
   location            = var.location

--- a/tests/remote/main.tftest.hcl
+++ b/tests/remote/main.tftest.hcl
@@ -1,7 +1,7 @@
 #
 # !! WIP !!
 # The remote test is currently not working and needs to be fixed ASAP!
-# https://github.com/cloudeteer/terraform-azurerm-azure-ai-foundry-hub/issues/2
+# https://github.com/cloudeteer/terraform-azurerm-ai-stack/issues/2
 #
 
 # run "remote" {


### PR DESCRIPTION
Update module source references to reflect the new ai-stack naming convention. Adjust documentation links accordingly.